### PR TITLE
Add Python 3.10 support

### DIFF
--- a/x16rt_module.c
+++ b/x16rt_module.c
@@ -1,3 +1,5 @@
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 #include "x16rt.h"


### PR DESCRIPTION
PEP-0353 is required for Python  >=3.10 to work. For more information: https://peps.python.org/pep-0353